### PR TITLE
WIP: A bounded 1D Gaussian KDE 

### DIFF
--- a/scipy/stats/kde.py
+++ b/scipy/stats/kde.py
@@ -49,6 +49,12 @@ class gaussian_kde(object):
     a unimodal distribution; bimodal or multi-modal distributions tend to be
     oversmoothed.
 
+    TODO: (for 1D KDEs to start with) allow upper and lower bounds on the KDE.
+    This will essentially involve changing the normalisation in the evaluation
+    function to take account of the fraction of the Gaussians outside the
+    bounds. This will also need to be factored into the integrate_box_1d
+    function.
+
     Parameters
     ----------
     dataset : array_like


### PR DESCRIPTION
Currently, when you produce a Gaussian KDE on data that has fixed bounds, the extent of the Kernel causes bleeding of probability outside of the bounds. This can be fixed by changing the normalisation to account for the fraction of the kernels that spread outside the bounds, and making sure the evaluating the KDE outside of the bounds returns zero. This should be simple to do for a 1D dataset, but could be more complicated in more dimensions, so I'll just start with the 1D case.

The fix to the normalisation will be required for both the `evaluate` method and the `integrate_1d_box` method.